### PR TITLE
Move search parameters from props to query string.

### DIFF
--- a/src/components/BasicSearch.vue
+++ b/src/components/BasicSearch.vue
@@ -73,8 +73,8 @@ export default {
     onSubmit: function() {
       // onSubmit is called when user inputs ENTER on search bar
       // proxy the event to the basicSearch function
-      var vm = this
-      vm.basicSearch()
+      var vm = this;
+      vm.basicSearch();
     },
     basicSearch: function() {
       // basicSearch is called when user clicks search button
@@ -83,48 +83,30 @@ export default {
       // Validate user input with regex
       vm.validateInput()
       if (vm.validated) {
-        var parsedQuery = vm.parseQuery()
-        // Send parsed query to Home component
-        this.$emit('basicSearch', parsedQuery)
-        // this.$emit('basicSearch', vm.query) // unparsed query string
+        this.$router.push({
+          path: "results",
+          query: {
+            query: vm.query,
+            assembly: vm.assembly
+          }
+        });
       } else {
-        vm.errorMessage = "Variant search term is malformed, please try again."
-        vm.errorTooltip = true
+        vm.errorMessage = "Variant search term is malformed, please try again.";
+        vm.errorTooltip = true;
       }
     },
     exampleSearch: function() {
-      var vm = this
-      vm.query = "MT : 10 T > C"
+      var vm = this;
+      vm.query = "MT : 10 T > C";
     },
     validateInput: function() {
-      var vm = this
+      var vm = this;
       if (vm.regex.exec(vm.query)) {
-        vm.validated = true
+        vm.validated = true;
       } else {
-        vm.validated = false
+        vm.validated = false;
       }
     },
-    parseQuery: function() {
-        var vm = this
-        var q = vm.query.split(" ")
-        var queryParams = {
-          "assemblyId": vm.assembly,
-          "referenceName": q[0],
-          "startMin": q[2] > 0 ? q[2]-1 : 0,
-          "startMax": q[2],
-          "referenceBases": q[3],
-        }
-
-        if (vm.variantTypes.includes(q[5])) {
-          // q[5] is a variantType
-          queryParams["variantType"] = q[5]
-        } else {
-          // q[5] is an alternateBases
-          queryParams["alternateBases"] = q[5]
-        }
-
-        return queryParams
-    }
   }
 };
 </script>

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -52,15 +52,24 @@
 
 <script>
 export default {
-    props: ["queryParams"],
     data() {
         return {
+            queryParams: undefined,
             hits: true,
             pub: true,
             registered: true,
             controlled: true,
             isLoading: false,
-            response: []
+            response: [],
+            variantTypes: ["DEL:ME", "INS:ME", "DUP:TANDEM", "DUP", "DEL", "INS", "INV", "CNV", "SNP", "MNP"]
+        }
+    },
+    watch: {
+        "$route.query.query": function() {
+            // Watch query string for changes in case the user makes a new
+            // search while displaying results.
+            this.parseQuery();
+            this.queryAPI();
         }
     },
     methods: {
@@ -106,9 +115,31 @@ export default {
                 console.log('Malformed query string.')
             }
             return baseString
+        },
+        parseQuery: function() {
+            var vm = this
+            var q = vm.$route.query.query.split(" ")
+            var queryParams = {
+              "assemblyId": vm.$route.query.assembly,
+              "referenceName": q[0],
+              "startMin": q[2] > 0 ? q[2]-1 : 0,
+              "startMax": q[2],
+              "referenceBases": q[3],
+            }
+
+            if (vm.variantTypes.includes(q[5])) {
+              // q[5] is a variantType
+              queryParams["variantType"] = q[5]
+            } else {
+              // q[5] is an alternateBases
+              queryParams["alternateBases"] = q[5]
+            }
+
+            vm.queryParams = queryParams
         }
     },
     beforeMount () {
+        this.parseQuery();
         this.queryAPI();
     }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,7 +6,7 @@
         <b-tag v-if="getCookie('bona_fide')" type="is-info">Bona Fide</b-tag>
       </b-taglist>
     </div>
-    <BasicSearch v-on:basicSearch="searchView" />
+    <BasicSearch />
     <router-view />
     <Footer />
   </div>
@@ -30,12 +30,6 @@ export default {
     }
   },
   methods: {
-    searchView: function(value) {
-      // Push route to the search view child route.
-      var vm = this
-      vm.queryParams = value
-      vm.$router.push({name: "searchresults", params: { queryParams: vm.queryParams }})
-    },
     devToast: function() {
       this.$snackbar.open({
         duration: 10000,


### PR DESCRIPTION
### Changes
Refactor `BasicSearch` to use query string to pass the parameters,
thus enabling the following:

- New searches can be made while displaying results.
- All searches can be copy-pasted as a full URL.
- Full search history can be preserved and traversed.

Fixes the problem with new queries not updating the view, when the results of previous query
are already displayed.