### PR TITLE
Fix null results in results

### DIFF
--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -46,20 +46,29 @@
 
         <b-table-column field="access" label="Dataset Access">
           <CheckboxBlankCircleIcon
-            v-if="props.row.datasetAlleleResponses.some(checkForPublicDatasets)"
+            v-if="
+              props.row.datasetAlleleResponses &&
+                props.row.datasetAlleleResponses.some(checkForPublicDatasets)
+            "
             title="Public"
             class="has-text-success"
           ></CheckboxBlankCircleIcon>
           <CheckboxBlankCircleIcon
             v-if="
-              props.row.datasetAlleleResponses.some(checkForRegisteredDatasets)
+              props.row.datasetAlleleResponses &&
+                props.row.datasetAlleleResponses.some(
+                  checkForRegisteredDatasets
+                )
             "
             title="Registered"
             class="has-text-warning"
           ></CheckboxBlankCircleIcon>
           <CheckboxBlankCircleIcon
             v-if="
-              props.row.datasetAlleleResponses.some(checkForControlledDatasets)
+              props.row.datasetAlleleResponses &&
+                props.row.datasetAlleleResponses.some(
+                  checkForControlledDatasets
+                )
             "
             title="Controlled"
             class="has-text-danger"
@@ -67,7 +76,11 @@
         </b-table-column>
 
         <b-table-column field="length" label="Variants Found" sortable numeric>
-          {{ props.row.datasetAlleleResponses.length }}
+          {{
+            props.row.datasetAlleleResponses
+              ? props.row.datasetAlleleResponses.length
+              : 0
+          }}
         </b-table-column>
       </template>
 

--- a/src/components/BeaconResultsRow.vue
+++ b/src/components/BeaconResultsRow.vue
@@ -1,15 +1,36 @@
 <template>
   <p class="org-row">
-    <img class="logo" :src="data.organization.logoUrl" :alt="data.name" />
-    <span class="name">{{ data.name }} at {{ data.organization.name }}</span>
+    <!-- Got data from Registry -->
+    <img
+      v-if="data.organization.logoUrl"
+      class="logo alt-color"
+      :src="data.organization.logoUrl"
+      :alt="data.name + ' Logo'"
+    />
+    <span v-if="data.organization.name" class="name"
+      >{{ data.name }} at {{ data.organization.name }}</span
+    >
+    <!-- Couldn't retrieve data from Registry -->
+    <Alert
+      v-if="!data.organization.logoUrl"
+      title="Could not retrieve Beacon data from Registry"
+      class="has-text-warning"
+    ></Alert>
+    <span v-if="!data.organization.name" class="name">{{
+      $props.beaconId
+    }}</span>
   </p>
 </template>
 
 <script>
 import axios from "axios";
+import Alert from "vue-material-design-icons/Alert.vue";
 
 export default {
   props: ["beaconId"],
+  components: {
+    Alert
+  },
   data() {
     return {
       registry: process.env.VUE_APP_REGISTRY_URL,
@@ -52,6 +73,8 @@ export default {
   padding: 0 0 0 10px;
   margin: 0;
   position: absolute;
-  /* top: 20%; */
+}
+.alt-color {
+  color: gray;
 }
 </style>


### PR DESCRIPTION
* Fixed table population error when `datasetAlleleResponses: null`
* Display beacon ID when we can't get beacon logo or organisation name from Registry
* Made image `alt` text gray to differentiate it from the organisation name

![Screenshot-2019-10-10 ELIXIR Beacon Network](https://user-images.githubusercontent.com/17040963/66561549-5c566900-eb62-11e9-8db6-523114c7b3c5.png)
