### PR TITLE
Fix Logout

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,5 @@ VUE_APP_REGISTRY_URL=https://dev-registry-beacon.rahtiapp.fi/
 VUE_APP_AGGREGATOR_URL=https://dev-aggregator-beacon.rahtiapp.fi/
 VUE_APP_UI_URL=https://dev-ui-beacon.rahtiapp.fi/
 VUE_APP_LOGIN_URL=https://auth-beacon.rahtiapp.fi/login
+VUE_APP_LOGOUT_URL=https://auth-beacon.rahtiapp.fi/logout
 VUE_APP_JWT_AUDIENCE=771678e5-bf28-4938-910a-4a28c614e64f

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,20 +14,14 @@
             src="./assets/beacon-network-logo.png"
         /></router-link>
       </div>
-      <a
-        v-if="!getCookie('logged_in')"
-        class="login"
-        href="https://auth-beacon.rahtiapp.fi/login"
+      <a v-if="!getCookie('logged_in')" class="login" :href="login_url"
         ><img src="./assets/elixir-login.png"
       /></a>
-      <b-button
-        v-if="getCookie('logged_in')"
-        class="login"
-        v-on:click="logOut"
-        type="is-primary"
-        size="is-medium"
-        >Log Out</b-button
-      >
+      <a v-if="getCookie('logged_in')" class="login" :href="logout_url">
+        <b-button class="login" type="is-primary" size="is-medium"
+          >Log Out</b-button
+        >
+      </a>
     </div>
     <router-view />
     <Footer />
@@ -37,16 +31,16 @@
 <script>
 import Footer from "@/components/Footer.vue";
 export default {
+  data() {
+    return {
+      login_url: process.env.VUE_APP_LOGIN_URL,
+      logout_url: process.env.VUE_APP_LOGOUT_URL
+    };
+  },
   components: {
     Footer
   },
   methods: {
-    logOut: function() {
-      // Function from https://www.w3schools.com/js/js_cookies.asp
-      // This function replaces the existing cookie with an instantly expiring one
-      document.cookie =
-        "access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-    },
     getCookie: function(cname) {
       // Function from https://www.w3schools.com/js/js_cookies.asp
       var name = cname + "=";

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,9 +18,7 @@
         ><img src="./assets/elixir-login.png"
       /></a>
       <a v-if="getCookie('logged_in')" class="login" :href="logout_url">
-        <b-button class="login" type="is-primary" size="is-medium"
-          >Log Out</b-button
-        >
+        <b-button class="login" type="is-primary">Log Out</b-button>
       </a>
     </div>
     <router-view />

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,11 +1,5 @@
 <template>
   <div class="home">
-    <div class="loggedStatus">
-      <b-taglist>
-        <b-tag v-if="getCookie('logged_in')" type="is-info">Logged In</b-tag>
-        <b-tag v-if="getCookie('bona_fide')" type="is-info">Bona Fide</b-tag>
-      </b-taglist>
-    </div>
     <p id="logo" v-if="$route.meta.hideSmallLogo">
       <router-link to="/">
         <img


### PR DESCRIPTION
Logout button didn't work, because the UI couldn't overwrite a cookie at the domain level.

New logout procedure uses the auth api, and revokes the token at AAI in addition to deleting the cookie (which is good) https://github.com/CSCfi/oidc-client/pull/13

Fixes #11 