### PR TITLE
Fix the no results remplate

### DIFF
--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -4,7 +4,9 @@
       <h6 class="subtitle">Filter results</h6>
       <b-field grouped group-multiline class="filtered">
         <div class="field">
-          <b-switch v-model="hits">Hits Only</b-switch>
+          <b-switch v-model="hits" :disabled="response.length < 1"
+            >Hits Only</b-switch
+          >
         </div>
       </b-field>
     </div>

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -242,6 +242,7 @@ export default {
         // The connection was closed
         vm.isLoading = false;
         // console.log('websocket closed');
+        vm.checkResponse();
       };
       websocket.onmessage = function(event) {
         // New message arrived
@@ -253,7 +254,16 @@ export default {
         // There was an error with your WebSocket
         vm.isLoading = false;
         // console.log('websocket errored');
+        vm.checkResponse();
       };
+    },
+    checkResponse: function() {
+      // Checks if the response from aggregator contains any exists=true
+      // If it doesn't, it clears the entire response array
+      // This solution stems from buefy's requirements for displaying
+      // an empty table template (display only if there is no data)
+      if (this.response.find(resp => resp.exists === true)) return true;
+      else this.response = [];
     },
     checkForPublicDatasets: function(result) {
       if (


### PR DESCRIPTION
Fixes #23 

* Displays the `empty` template when no data was found;
* Disables the hits filter when no data was found.