### PR TITLE
Small fixes

### DIFF
--- a/src/components/AdvancedSearch.vue
+++ b/src/components/AdvancedSearch.vue
@@ -383,4 +383,8 @@ span#basicSearch {
 .column-top-margin {
   margin-top: 20px;
 }
+/* fix safari bug https://github.com/jgthms/bulma/issues/2626 */
+.select select {
+  text-rendering: auto !important;
+}
 </style>

--- a/src/components/BasicSearch.vue
+++ b/src/components/BasicSearch.vue
@@ -189,4 +189,8 @@ h2 {
 #searchBar {
   border-radius: 0;
 }
+/* fix safari bug https://github.com/jgthms/bulma/issues/2626 */
+.select select {
+  text-rendering: auto !important;
+}
 </style>

--- a/src/components/HomeTabs.vue
+++ b/src/components/HomeTabs.vue
@@ -171,6 +171,7 @@ export default {
   methods: {
     changeSearch: function(queryString) {
       this.$root.$emit("changeSearch", queryString);
+      document.getElementById("app").scrollIntoView();
     }
   }
 };

--- a/src/views/Join.vue
+++ b/src/views/Join.vue
@@ -1,8 +1,8 @@
 <template>
   <section>
-    <div class="columns content return-container">
-      <router-link to="/">Return</router-link>
-    </div>
+    <b-button tag="router-link" to="/" type="is-info">
+      Return to main page
+    </b-button>
 
     <div class="columns content form-container">
       <div class="column">

--- a/src/views/Join.vue
+++ b/src/views/Join.vue
@@ -60,11 +60,7 @@
           </ConnectedBeaconTile>
         </div>
         <div v-if="response">
-          <b-message
-            v-bind:title="response.statusText"
-            type="is-success"
-            aria-close-label="Close message"
-          >
+          <b-message type="is-success">
             {{ response.data.message }}<br />
             <b>Service ID:</b> {{ response.data.serviceId }}<br />
             <b>Service Key:</b> {{ response.data.serviceKey }}<br />
@@ -72,11 +68,7 @@
           </b-message>
         </div>
         <div v-if="!response && error">
-          <b-message
-            v-bind:title="error.statusText"
-            type="is-warning"
-            aria-close-label="Close message"
-          >
+          <b-message type="is-warning">
             {{ error.data }}
           </b-message>
         </div>


### PR DESCRIPTION
* Changed return-button in `/join` to be the same as in other views;
* Changed message in `/join` to be the same as in search validation, fixes the bug when user closes message, and the message doesn't reappear again when it should;
* Made the `try` button in tabs _show examples_ scroll window to top to show the inserted query;
* Fixed bulma bug where using `select` dropdown would crash Safari.