### PR TITLE
Toggle for display results an no white on gray

### DIFF
--- a/src/components/BeaconResultTileDetails.vue
+++ b/src/components/BeaconResultTileDetails.vue
@@ -5,9 +5,13 @@
         @click="displayResults"
         class="show-more"
         type="is-primary"
-        title="Show detailed response"
+        :title="!display ? 'Show detailed response' : 'Hide detailed response'"
       >
-        Display {{ results.length }} result(s)
+        {{
+          !display
+            ? "Display " + results.length + " result(s)"
+            : "Hide result(s)"
+        }}
       </b-button>
       <div v-if="display" class="details-rows">
         <b-table :data="results" :striped="true" class="column details-table">
@@ -142,9 +146,9 @@ export default {
   background: linear-gradient(0deg, rgba(224,224,224,1) 0%, rgba(255,255,255,1) 10%);  */
   /* border-bottom: 5px solid #047eaa; */
 }
-.show-more:hover {
+/* .show-more:hover {
   background-color: #e0e0e0;
-}
+} */
 .narrow-column {
   width: 15%;
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->

Add toggle to display results showing different message depending if results are displayed or not.
Fixed also white text on gray background when hovering the button, that made it difficult to see the text.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
![Peek 2019-11-25 11-47](https://user-images.githubusercontent.com/47524/69529674-65b45d00-0f79-11ea-99bf-b319b4aae176.gif)

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
