### PR TITLE
ELIXIR & Accessibility

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="app">
+    <h1 style="display:none">ELIXIR Beacon Network</h1>
     <div
       id="nav"
       :class="[

--- a/src/App.vue
+++ b/src/App.vue
@@ -125,6 +125,8 @@ body {
 // Set your colors
 $primary: #047eaa;
 $primary-invert: findColorInvert($primary);
+$snackbar-background-color: #ffcc00;
+$snackbar-color: #000;
 $colors: (
   "primary": (
     $primary,

--- a/src/App.vue
+++ b/src/App.vue
@@ -124,22 +124,10 @@ body {
 // Set your colors
 $primary: #047eaa;
 $primary-invert: findColorInvert($primary);
-$success: #147636;
-$success-invert: findColorInvert($success);
-$danger: #eb002f;
-$danger-invert: findColorInvert($danger);
 $colors: (
   "primary": (
     $primary,
     $primary-invert
-  ),
-  "success": (
-    $success,
-    $success-invert
-  ),
-  "danger": (
-    $danger,
-    $danger-invert
   )
 );
 

--- a/src/components/AdvancedSearch.vue
+++ b/src/components/AdvancedSearch.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container content">
     <form @submit.prevent="advancedSearch" title="Advanced Search Options">
-      <h4>Variant Location</h4>
+      <h2>Variant Location</h2>
       <div class="columns">
         <div class="column">
           <b-field label="Assembly">
@@ -110,7 +110,7 @@
         </div>
       </div>
 
-      <h4>Variant Transformation</h4>
+      <h2>Variant Transformation</h2>
       <hr />
       <div class="columns">
         <div class="column">

--- a/src/components/AdvancedSearch.vue
+++ b/src/components/AdvancedSearch.vue
@@ -4,37 +4,40 @@
       <h2>Variant Location</h2>
       <div class="columns">
         <div class="column">
-          <b-field label="Assembly">
-            <b-select title="Assembly ID" v-model="assembly" expanded>
-              <option
-                v-for="asm in assemblies"
-                :value="asm"
-                :key="asm"
-                :title="'Assembly ID ' + asm"
-              >
-                {{ asm }}
-              </option>
-            </b-select>
-          </b-field>
+          <label class="form-label" for="assembly">Assembly</label>
+          <b-select
+            id="assembly"
+            title="Assembly ID"
+            v-model="assembly"
+            expanded
+          >
+            <option
+              v-for="asm in assemblies"
+              :value="asm"
+              :key="asm"
+              :title="'Assembly ID ' + asm"
+            >
+              {{ asm }}
+            </option>
+          </b-select>
         </div>
         <div class="column">
-          <b-field label="Chromosome">
-            <b-select
-              title="Chromosome"
-              id="chromosome"
-              v-model="referenceName"
-              expanded
+          <label class="form-label" for="chromosome">Chromosome</label>
+          <b-select
+            title="Chromosome"
+            id="chromosome"
+            v-model="referenceName"
+            expanded
+          >
+            <option
+              v-for="ref in referenceNames"
+              :value="ref"
+              :key="ref"
+              :title="'Chromosome ' + ref"
             >
-              <option
-                v-for="ref in referenceNames"
-                :value="ref"
-                :key="ref"
-                :title="'Chromosome ' + ref"
-              >
-                {{ ref }}
-              </option>
-            </b-select>
-          </b-field>
+              {{ ref }}
+            </option>
+          </b-select>
         </div>
         <div class="column">
           <fieldset>
@@ -52,61 +55,79 @@
           </fieldset>
         </div>
         <div class="column">
-          <b-field label="Start" v-if="coordType === 'exact'">
-            <b-input
-              type="number"
-              v-model="start"
-              controls-position="compact"
-              min="0"
-              title="Exact start coordinate"
-            ></b-input>
-          </b-field>
-          <b-field label="Minimum Start" v-if="coordType === 'range'">
-            <b-input
-              type="number"
-              v-model="startMin"
-              controls-position="compact"
-              min="0"
-              title="Minimum start coordinate of range"
-            ></b-input>
-          </b-field>
-          <b-field label="Maximum Start" v-if="coordType === 'range'">
-            <b-input
-              type="number"
-              v-model="startMax"
-              controls-position="compact"
-              min="0"
-              title="Maximum start coordinate of range"
-            ></b-input>
-          </b-field>
+          <label class="form-label" for="start" v-if="coordType === 'exact'"
+            >Start</label
+          >
+          <b-input
+            id="start"
+            v-if="coordType === 'exact'"
+            type="number"
+            v-model="start"
+            controls-position="compact"
+            min="0"
+            title="Exact start coordinate"
+          ></b-input>
+          <label class="form-label" for="minStart" v-if="coordType === 'range'"
+            >Minimum Start</label
+          >
+          <b-input
+            id="minStart"
+            v-if="coordType === 'range'"
+            type="number"
+            v-model="startMin"
+            controls-position="compact"
+            min="0"
+            title="Minimum start coordinate of range"
+          ></b-input>
+          <label class="form-label" for="maxStart" v-if="coordType === 'range'"
+            >Maximum Start</label
+          >
+          <b-input
+            id="maxStart"
+            v-if="coordType === 'range'"
+            type="number"
+            v-model="startMax"
+            controls-position="compact"
+            min="0"
+            title="Maximum start coordinate of range"
+          ></b-input>
         </div>
         <div class="column">
-          <b-field label="End" v-if="coordType === 'exact'">
-            <b-input
-              type="number"
-              v-model="end"
-              min="0"
-              title="Exact end coordinate"
-            ></b-input>
-          </b-field>
-          <b-field label="Minimum End" v-if="coordType === 'range'">
-            <b-input
-              type="number"
-              v-model="endMin"
-              controls-position="compact"
-              min="0"
-              title="Minimum end coordinate of range"
-            ></b-input>
-          </b-field>
-          <b-field label="Maximum End" v-if="coordType === 'range'">
-            <b-input
-              type="number"
-              v-model="endMax"
-              controls-position="compact"
-              min="0"
-              title="Maximum end coordinate of range"
-            ></b-input>
-          </b-field>
+          <label class="form-label" for="end" v-if="coordType === 'exact'"
+            >End</label
+          >
+          <b-input
+            id="end"
+            v-if="coordType === 'exact'"
+            type="number"
+            v-model="end"
+            min="0"
+            title="Exact end coordinate"
+          ></b-input>
+          <label class="form-label" for="minEnd" v-if="coordType === 'range'"
+            >Minimum End</label
+          >
+          <b-input
+            id="minEnd"
+            v-if="coordType === 'range'"
+            type="number"
+            v-model="endMin"
+            controls-position="compact"
+            min="0"
+            title="Minimum end coordinate of range"
+          ></b-input>
+          <label class="form-label" for="maxEnd" v-if="coordType === 'range'"
+            >Maximum End</label
+          >
+          <b-input
+            id="maxEnd"
+            v-if="coordType === 'range'"
+            type="number"
+            v-model="endMax"
+            controls-position="compact"
+            min="0"
+            title="Maximum end coordinate of range"
+          ></b-input>
         </div>
       </div>
 
@@ -114,46 +135,50 @@
       <hr />
       <div class="columns">
         <div class="column">
-          <b-field label="Reference Base(s)">
-            <b-input
-              v-model="refBases"
-              pattern="[ATCGN]+"
-              placeholder="ATCGN"
-              expanded
-              title="Sequence of reference bases"
-            ></b-input>
-          </b-field>
+          <label class="form-label" for="referenceBases"
+            >Reference Base(s)</label
+          >
+          <b-input
+            id="referenceBases"
+            v-model="refBases"
+            pattern="[ATCGN]+"
+            placeholder="ATCGN"
+            expanded
+            title="Sequence of reference bases"
+          ></b-input>
         </div>
         <div class="column">
-          <b-field label="Alternate Base(s)">
-            <b-input
-              v-model="altBases"
-              v-on:input="resetVariantType"
-              pattern="[ATCGN]+"
-              placeholder="ATCGN"
-              expanded
-              title="Sequence of alternate bases"
-            ></b-input>
-          </b-field>
+          <label class="form-label" for="alternateBases"
+            >Alternate Base(s)</label
+          >
+          <b-input
+            id="alternateBases"
+            v-model="altBases"
+            v-on:input="resetVariantType"
+            pattern="[ATCGN]+"
+            placeholder="ATCGN"
+            expanded
+            title="Sequence of alternate bases"
+          ></b-input>
         </div>
         <div class="column">
-          <b-field label="Variant Type">
-            <b-select
-              v-model="variantType"
-              v-on:input="resetAltBases"
-              expanded
-              title="Variant type"
+          <label class="form-label" for="variantType">Variant Type</label>
+          <b-select
+            id="variantType"
+            v-model="variantType"
+            v-on:input="resetAltBases"
+            expanded
+            title="Variant type"
+          >
+            <option
+              v-for="vt in variantTypes"
+              :value="vt"
+              :key="vt"
+              :title="'Variant type ' + vt"
             >
-              <option
-                v-for="vt in variantTypes"
-                :value="vt"
-                :key="vt"
-                :title="'Variant type ' + vt"
-              >
-                {{ vt }}
-              </option>
-            </b-select>
-          </b-field>
+              {{ vt }}
+            </option>
+          </b-select>
         </div>
       </div>
 
@@ -428,5 +453,12 @@ span#basicSearch {
 /* fix safari bug https://github.com/jgthms/bulma/issues/2626 */
 .select select {
   text-rendering: auto !important;
+}
+.form-label {
+  color: #363636;
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5em;
 }
 </style>

--- a/src/components/BasicSearch.vue
+++ b/src/components/BasicSearch.vue
@@ -4,24 +4,25 @@
       <form @submit.prevent="onSubmit">
         <b-field>
           <p class="control">
-            <b-field>
-              <b-select
-                placeholder="Assembly"
-                v-model="assembly"
-                size="is-medium"
-                title="Assembly ID"
-              >
-                <option value="GRCh38">GRCh38</option>
-                <option value="GRCh37">GRCh37</option>
-                <option value="hg19">hg19</option>
-              </b-select>
-            </b-field>
+            <label for="assembly" style="display:none">Assembly</label>
+            <b-select
+              id="assembly"
+              placeholder="Assembly"
+              v-model="assembly"
+              size="is-medium"
+              title="Assembly ID"
+            >
+              <option value="GRCh38">GRCh38</option>
+              <option value="GRCh37">GRCh37</option>
+              <option value="hg19">hg19</option>
+            </b-select>
           </p>
           <b-tooltip
             class="stretch"
             animated
             label="Chromosome : Position ReferenceBase > AlternateBase|VariantType"
           >
+            <label for="searchBar" style="display:none">Search Bar</label>
             <b-input
               id="searchBar"
               class="stretch searchbar"

--- a/src/components/BeaconResultTile.vue
+++ b/src/components/BeaconResultTile.vue
@@ -40,14 +40,12 @@
         <div class="media-right">
           <b-tag
             v-if="exists"
-            type="is-success"
             class="accessibility-green-tag"
             title="A variant was found"
             ><b>Found</b></b-tag
           >
           <b-tag
             v-if="!exists"
-            type="is-danger"
             class="accessibility-red-tag"
             title="No variants were found"
             ><b>Not Found</b></b-tag
@@ -96,9 +94,11 @@ export default {
 
 <style scoped>
 .accessibility-green-tag {
-  background-color: #147636;
+  background-color: #29852a;
+  color: #fff;
 }
 .accessibility-red-tag {
-  background-color: #eb002f;
+  background-color: #e90000;
+  color: #fff;
 }
 </style>

--- a/src/components/BeaconResultTileDetails.vue
+++ b/src/components/BeaconResultTileDetails.vue
@@ -18,22 +18,19 @@
           <template slot-scope="results">
             <b-table-column label="Access">
               <b-tag
-                class="access-tag"
-                type="is-success"
+                class="accessibility-green-tag"
                 v-if="checkForPublicDatasets(results.row)"
                 title="Dataset is in public access"
                 ><b>Public</b></b-tag
               >
               <b-tag
-                class="access-tag"
-                type="is-warning"
+                class="accessibility-yellow-tag"
                 v-else-if="checkForRegisteredDatasets(results.row)"
                 title="Dataset requires ELIXIR Bona Fide status to access"
                 ><b>Registered</b></b-tag
               >
               <b-tag
-                class="access-tag"
-                type="is-danger"
+                class="accessibility-red-tag"
                 v-else-if="checkForControlledDatasets(results.row)"
                 title="Dataset requires permissions from data owner to access"
                 ><b>Controlled</b></b-tag
@@ -172,5 +169,17 @@ export default {
     rgba(255, 255, 255, 1) 100%
   );
   margin-top: -10px;
+}
+.accessibility-green-tag {
+  background-color: #29852a;
+  color: #fff;
+}
+.accessibility-yellow-tag {
+  background-color: #ffcc00;
+  color: #000;
+}
+.accessibility-red-tag {
+  background-color: #e90000;
+  color: #fff;
 }
 </style>

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="container columns results-table">
     <div class="column is-one-fifth">
-      <h6 class="subtitle">Filter results</h6>
+      <p class="subtitle">Filter results</p>
       <b-field grouped group-multiline class="filtered">
         <div class="field">
           <b-switch

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -8,7 +8,7 @@
             class="column"
             title="ELIXIR Beacon Network website internal navigation"
           >
-            <h5>ELIXIR Beacon Network</h5>
+            <p class="footer-heading">ELIXIR Beacon Network</p>
             <ul>
               <li>
                 <router-link
@@ -46,7 +46,7 @@
             </ul>
           </div>
           <div class="column" title="Affiliated external links">
-            <h5>More About Beacon</h5>
+            <p class="footer-heading">More About Beacon</p>
             <ul>
               <li>
                 <a
@@ -217,5 +217,11 @@ export default {
   height: 30px;
   float: left;
   margin: 5px 10px 0 0;
+}
+.footer-heading {
+  color: #fff;
+  border-bottom: solid 1px #fff;
+  font-weight: 700;
+  font-size: 16px;
 }
 </style>

--- a/src/views/Accessibility.vue
+++ b/src/views/Accessibility.vue
@@ -64,7 +64,7 @@
 <style lang="scss" scoped>
 .word-wrap {
   margin: 0 auto;
-  max-width: 130ch;
+  max-width: 80ch;
   padding-bottom: 25px;
   text-align: left;
 }

--- a/src/views/Accessibility.vue
+++ b/src/views/Accessibility.vue
@@ -33,10 +33,7 @@
     <h4>Screen Reader Friendliness</h4>
     <p>
       Most elements and features on this website have been described for screen
-      readers. Semantic HTML elements are used in most features. Some features
-      may not be accessible due to limitations of the
-      <a href="https://buefy.org/">Buefy framework</a>, such as orphaned form
-      labels.
+      readers. Semantic HTML elements are used in most features.
     </p>
     <h4>Contrast</h4>
     <p>
@@ -44,13 +41,19 @@
       aware, that contrast is lower than desirable on default HTML select
       elements.
     </p>
+    <h3>Browser Support</h3>
+    <p>
+      This website has been tested to function correctly on the latest versions
+      of Google Chrome, Mozilla Firefox and Microsoft Edge browsers. (see date
+      of last update from bottom of this page)
+    </p>
     <h3>Upgrade</h3>
     <p>
       This accessibility statement may be reviewed and upgraded to satisfy WCAG
       2.1 level AA if needed.
     </p>
     <h3>Changes to Accessibility Statement</h3>
-    <p><br /><i>Last updated: 22 November 2019.</i></p>
+    <p><br /><i>Last updated: 26 November 2019.</i></p>
     <h3>Contact Us</h3>
     <p>
       Should any questions or suggestions emerge, we urge you to contact us at

--- a/src/views/Docs.vue
+++ b/src/views/Docs.vue
@@ -62,7 +62,7 @@
 <style lang="scss" scoped>
 .word-wrap {
   margin: 0 auto;
-  max-width: 130ch;
+  max-width: 80ch;
   padding-bottom: 25px;
   text-align: left;
 }

--- a/src/views/DocsApi.vue
+++ b/src/views/DocsApi.vue
@@ -76,7 +76,7 @@ export default {
 <style lang="scss" scoped>
 .word-wrap {
   margin: 0 auto;
-  max-width: 130ch;
+  max-width: 80ch;
   padding-bottom: 25px;
   text-align: left;
 }

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -5,7 +5,7 @@
     </b-button>
     <h1>How to use Beacon Network</h1>
     <h2>Making Queries</h2>
-    <h4>Basic Search</h4>
+    <h3>Basic Search</h3>
     <p>
       The Beacon Network searchbar is a simple form with two options: selection
       of assembly and definition of variant. The assembly can be selected from
@@ -13,7 +13,7 @@
       variant information as a search term which will be sent to Beacons in a
       structured manner.
     </p>
-    <h4>Basic Search Structure</h4>
+    <h3>Basic Search Structure</h3>
     <p>
       The search structure follows a strict convention of:
     </p>
@@ -30,13 +30,13 @@
       Network UI are substracted by one, and received at the Beacon APIs as
       0-based.
     </p>
-    <h4>Advanced Search</h4>
+    <h3>Advanced Search</h3>
     <p>
       To access more search options, see the advanced search button below the
       basic searchbar.
     </p>
     <h2>Example Queries</h2>
-    <h5>Example query:</h5>
+    <h3>Example query:</h3>
     <p>
       I want to find a genomic dataset which has samples of insertion type
       variants in chromosome 1 at position 104431390 where the reference base is
@@ -53,7 +53,7 @@
       </div>
       <pre>1 : 104431390 C > INS</pre>
     </figure>
-    <h5>Example query:</h5>
+    <h3>Example query:</h3>
     <p>
       I want to find a genomic dataset which has samples of single nucleotide
       polymorphism type of variant in the mitochondrial chromosome at position
@@ -71,7 +71,7 @@
       </div>
       <pre>MT : 7600 G > A</pre>
     </figure>
-    <h5>Example query:</h5>
+    <h3>Example query:</h3>
     <p>
       I want to find a genomic dataset which has samples of multiple nucleotide
       polymorphism type of variant in the mitochondrial chromosome at position

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -135,7 +135,7 @@ export default {
 <style lang="scss" scoped>
 .word-wrap {
   margin: 0 auto;
-  max-width: 130ch;
+  max-width: 80ch;
   padding-bottom: 25px;
   text-align: left;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -56,33 +56,18 @@ export default {
         this.componentName = BasicSearch;
       }
     },
-    devToast: function() {
-      this.$snackbar.open({
-        duration: 20000,
-        queue: false,
-        message:
-          "This web page is under development and may exhibit funky behaviour.",
-        actionText: "Cool",
-        onAction: () => {
-          this.$toast.open({
-            queue: false,
-            message: "Thanks for understanding!",
-            position: "is-bottom-right"
-          });
-        }
-      });
-    },
     cookieToast: function() {
       // Check if cookies have been accepted, if not, show toast regarding cookies
       if (!VueCookies.get("elixir-cookies")) {
         this.$snackbar.open({
-          duration: 20000,
+          indefinite: true,
           queue: false,
           message:
-            "Beacon Network utilises cookies. By using Beacon Network you accept the use of these cookies," +
-            ' more information regarding this can be read from the <a href="/privacy">Privacy Policy</a>.' +
-            ' Users are also subject to the <a href="/tos">Terms of Service</a>.',
+            "Beacon Network utilises cookies. By using Beacon Network you accept to the use of these cookies," +
+            ' more information regarding cookies can be read from the <a href="/privacy" style="color:#000DFF">Privacy Policy</a>.' +
+            ' Users are also subject to the <a href="/tos" style="color:#000DFF">Terms of Service</a>.',
           actionText: "OK",
+          type: "is-dark",
           onAction: () => {
             // Set a cookie to prevent toast on subsequent visits
             VueCookies.set("elixir-cookies", "accepted", Infinity);
@@ -114,7 +99,6 @@ export default {
   },
   beforeMount() {
     this.cookieToast();
-    this.devToast();
   }
 };
 </script>

--- a/src/views/Join.vue
+++ b/src/views/Join.vue
@@ -8,38 +8,36 @@
       <div class="column">
         <form @submit.prevent="onSubmit">
           <h2>Beacon Registration Form</h2>
-          <b-field
-            label="Beacon Info Endpoint"
-            message="https:// address to the info endpoint of this Beacon"
+          <label class="form-label" for="url">Beacon Info Endpoint</label>
+          <b-input
+            required
+            v-model="url"
+            id="url"
+            type="url"
+            pattern="https://.*"
+            maxlength="512"
+            placeholder="https://beacon.org/"
+            title="Info endpoint of the Beacon API"
           >
-            <b-input
-              required
-              v-model="url"
-              id="url"
-              type="url"
-              pattern="https://.*"
-              maxlength="512"
-              placeholder="https://beacon.org/"
-              title="Info endpoint of the Beacon API"
-            >
-            </b-input>
-          </b-field>
-          <b-field
-            label="API Key"
-            message="API key to authorise this registration"
+          </b-input>
+          <span class="input-subtitle"
+            >https:// address to the info endpoint of this Beacon</span
           >
-            <b-input
-              required
-              v-model="apikey"
-              id="apikey"
-              type="password"
-              minlength="64"
-              maxlength="64"
-              placeholder="secret"
-              title="API key provided by ELIXIR"
-            >
-            </b-input>
-          </b-field>
+          <label class="form-label" for="apiKey">API Key</label>
+          <b-input
+            required
+            v-model="apikey"
+            id="apiKey"
+            type="password"
+            minlength="64"
+            maxlength="64"
+            placeholder="secret"
+            title="API key provided by ELIXIR"
+          >
+          </b-input>
+          <span class="input-subtitle"
+            >API key to authorise this registration</span
+          >
           <b-field
             message="By registering you confirm that your Beacon service will uphold to the service requirements listed below."
           >
@@ -260,6 +258,19 @@ export default {
   margin: auto auto auto 15px;
 }
 code {
-  color: #85142b;
+  color: #000;
+}
+.form-label {
+  color: #363636;
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5em;
+}
+.input-subtitle {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: -1rem;
+  margin-bottom: 1rem;
 }
 </style>

--- a/src/views/Privacy.vue
+++ b/src/views/Privacy.vue
@@ -90,7 +90,7 @@
 <style lang="scss" scoped>
 .word-wrap {
   margin: 0 auto;
-  max-width: 130ch;
+  max-width: 80ch;
   padding-bottom: 25px;
   text-align: left;
 }

--- a/src/views/Tos.vue
+++ b/src/views/Tos.vue
@@ -58,7 +58,7 @@
 <style lang="scss" scoped>
 .word-wrap {
   margin: 0 auto;
-  max-width: 130ch;
+  max-width: 80ch;
   padding-bottom: 25px;
   text-align: left;
 }


### PR DESCRIPTION
### Description
Fix problems that emerged from the previous ELIXIR and accessibility PRs.

### Changes Made
* Global CSS changes improved contrast in some places and made it worse elsewhere, removed the global CSS and used better contrasting colours where they are needed (results page green, yellow and red tags)
* Reduced text column widths down to 80 characters as per WAI recommendation (did not change the `/join` view, as that is pending a facelift with #13 )
* Fixed inconsistent use of HTML headings (now `h1` is always on top of every page and subheadings are used incrementally)
* Buefy `b-field labels` didn't work and resulted in orphaned form input labels. Replaced these with default HTML labels, which fixed the issue

### To do
- [x] Update accessibility statement #31 

### Mentions
@sampsapenna helped in reviewing the WCAG 2.0 AA requirements and making suggestions for improvements.
