### PR TITLE
Fix Beacon response coordinates

### DIFF
--- a/src/components/BeaconResultTileDetails.vue
+++ b/src/components/BeaconResultTileDetails.vue
@@ -65,9 +65,20 @@
               label="Region"
               title="Start and end coordinates of this variant"
             >
-              {{ results.row.referenceName }}:{{ results.row.start }}-{{
-                results.row.end
-              }}
+              <div
+                v-if="
+                  results.row.referenceName &&
+                    results.row.start &&
+                    results.row.end
+                "
+              >
+                {{ results.row.referenceName }}:{{ results.row.start + 1 }}-{{
+                  results.row.end + 1
+                }}
+              </div>
+              <div v-else title="Some information is missing">
+                ?
+              </div>
             </b-table-column>
             <b-table-column label="AC" title="Allele Count">
               {{ results.row.variantCount }}


### PR DESCRIPTION
### Description
The UI is using 1-based coordinate system and Beacon APIs use 0-based coordinate system.

When a query was made, e.g. at position 10, a response was given for position 9. This change adds 1 to the response, so the results are displayed as 1-based. Additionally, because the coordinate response is an additional feature to the base Beacon specification, the _Region_ column is not displayed if one of the following keys is not found in the `datasetAlleleResponses` object: `referenceName`, `start`, `end`; a question mark `?` is displayed instead.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
* Add 1 to response coordinates if they exist in `BeaconResultTileDetails.vue`