### PR TITLE
CORS policy update and other

### DIFF
--- a/src/components/ConnectedBeaconTile.vue
+++ b/src/components/ConnectedBeaconTile.vue
@@ -38,54 +38,13 @@
             ></small
           >
         </div>
-        <div class="media-right">
-          <span v-if="status == 200">
-            <CheckboxBlankCircleIcon
-              :title="beacon.name + ' is reachable'"
-              class="has-text-success"
-            ></CheckboxBlankCircleIcon>
-          </span>
-          <span v-else>
-            <CheckboxBlankCircleIcon
-              :title="beacon.name + ' is not reachable'"
-              class="has-text-danger"
-            ></CheckboxBlankCircleIcon>
-          </span>
-        </div>
       </article>
     </div>
   </div>
 </template>
 
 <script>
-import axios from "axios";
-import CheckboxBlankCircleIcon from "vue-material-design-icons/CheckboxBlankCircle.vue";
-
 export default {
-  components: {
-    CheckboxBlankCircleIcon
-  },
-  props: ["beacon"],
-  data: function() {
-    return {
-      status: 404
-    };
-  },
-  methods: {
-    checkStatus: function() {
-      axios
-        .head(this.$props.beacon.url)
-        .then(response => {
-          // console.log(this.$props.beacon.url, response.status)
-          this.status = response.status;
-        })
-        .catch(error => {
-          console.log(this.$props.beacon.url, error);
-        });
-    }
-  },
-  beforeMount() {
-    this.checkStatus();
-  }
+  props: ["beacon"]
 };
 </script>

--- a/src/views/Join.vue
+++ b/src/views/Join.vue
@@ -104,9 +104,6 @@
             user access tokens must be validated from their third party
             origins.<b>*</b>
           </li>
-          <li>
-            Service must have CORS enabled
-          </li>
         </ol>
         <p>
           <i
@@ -151,13 +148,26 @@
           <li>
             Beacon API specification doesn't declare how to indicate a dataset's
             access level. To convey this information in the UI, the Beacon can
-            add <code>{"accessType": level}</code> to
+            add <code>{"accessType": "LEVEL"}</code> to
             <code>datasetAlleleResponses</code>'s <code>info</code> key. The
-            possible values are <code>PUBLIC</code>, <code>REGISTERED</code> and
-            <code>CONTROLLED</code>.
+            possible values are <code>"PUBLIC"</code> for public access,
+            <code>"REGISTERED"</code> for Bona Fide access and
+            <code>"CONTROLLED"</code> for application-controlled access. See the
             <a
               href="https://beaconpy-elixirbeacon.rahtiapp.fi/query?assemblyId=GRCh38&referenceName=MT&start=9&referenceBases=T&alternateBases=C&includeDatasetResponses=HIT"
-              >Example response</a
+              >example response</a
+            >
+            for how to specify a dataset's access level.
+          </li>
+          <li>
+            Additional extra-specification values displayed in the results table
+            are <code>referenceBases</code>, <code>alternateBases</code> and
+            <code>variantType</code> which are useful for clarifying wildcards
+            results. <code>start</code> and <code>end</code> can also be added
+            to give insight on range queries. These keys are also shown in the
+            <a
+              href="https://beaconpy-elixirbeacon.rahtiapp.fi/query?assemblyId=GRCh38&referenceName=MT&start=9&referenceBases=T&alternateBases=C&includeDatasetResponses=HIT"
+              >example response</a
             >.
           </li>
         </ol>


### PR DESCRIPTION
### Description
Beacon APIs are reachable by the Aggregator API even if the Beacons don't have CORS enabled. Some Beacons have difficulties dealing with CORS, which causes the front page to show a red circle on them. Removed CORS policy from the registration requirements and removed the green/red status check circle on Beacons, as it gave false information.

### Changes Made
* Removed green/red circle from front page Beacons
* Removed CORS policy from `/join`
* Added more information to `/join` regarding extra-specification features