### PR TITLE
Retain inputs on page reload

### DIFF
--- a/src/components/AdvancedSearch.vue
+++ b/src/components/AdvancedSearch.vue
@@ -295,7 +295,6 @@ export default {
       ]
     };
   },
-  props: {},
   methods: {
     changeSearchForm: function() {
       this.$emit("changeSearchForm");
@@ -355,6 +354,8 @@ export default {
       if (this.errorMessages.length === 0) {
         // Base query string
         var queryObj = {
+          searchType: "advanced",
+          coordType: this.coordType,
           includeDatasetResponses: "HIT",
           assemblyId: this.assembly,
           referenceName: this.referenceName,
@@ -422,6 +423,31 @@ export default {
       this.altBases = "";
       this.variantType = "Unspecified";
     }
+  },
+  beforeMount() {
+    // If user reloads page, this places the current query params from the address bar into the search form
+    // Check searchType
+    if (this.$route.query.searchType == "advanced") {
+      // Continue to parse the object into form inputs
+      this.assembly = this.$route.query.assemblyId;
+      this.referenceName = this.$route.query.referenceName;
+      this.coordType = this.$route.query.coordType;
+      this.start = parseInt(this.$route.query.start) + 1;
+      this.end = parseInt(this.$route.query.end) + 1;
+      this.startMin = parseInt(this.$route.query.startMin) + 1;
+      this.startMax = parseInt(this.$route.query.startMax) + 1;
+      this.endMin = parseInt(this.$route.query.endMin) + 1;
+      this.endMax = parseInt(this.$route.query.endMax) + 1;
+      this.refBases = this.$route.query.referenceBases;
+      this.altBases = this.$route.query.alternateBases;
+      this.variantType = this.$route.query.variantType;
+    }
+    // We don't need an `else`-statement to display the BasicSearch.vue, because BasicSearch.vue
+    // is always the first component to show on page refresh, which then redirects to AdvancedSearch.vue
+    // else {
+    //   // Default to basic search
+    //   this.changeSearchForm();
+    // }
   }
 };
 </script>

--- a/src/components/BasicSearch.vue
+++ b/src/components/BasicSearch.vue
@@ -116,6 +116,7 @@ export default {
       if (vm.validated) {
         // Query string
         var queryObj = {
+          searchType: "basic",
           includeDatasetResponses: "HIT",
           assemblyId: vm.assembly,
           referenceName: vm.query.split(" ")[0],
@@ -156,6 +157,25 @@ export default {
       } else {
         vm.validated = false;
       }
+    }
+  },
+  beforeMount() {
+    // If user reloads page, this places the current query params from the address bar into the search bar
+    // Check searchType
+    if (this.$route.query.searchType == "basic") {
+      // Continue to parse the object into a string
+      this.query = `${this.$route.query.referenceName} : ${parseInt(
+        this.$route.query.start,
+        10
+      ) + 1} ${this.$route.query.referenceBases} > ${
+        this.$route.query.alternateBases
+      }`;
+    } else if (this.$route.query.searchType == "advanced") {
+      // Change to advanced search form
+      this.changeSearchForm();
+    } else {
+      // Default to basic search
+      this.query = "";
     }
   }
 };

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -119,7 +119,12 @@ export default {
       var wss = vm.aggregator.replace("https", "wss"); // change aggregator https url to wss
 
       // Query params parsing from string https://stackoverflow.com/a/6566471/8166034
-      var queryParamsObj = this.$route.query;
+      // Copy the query object and remove the unwanted keys, so that we can use
+      // the pristine query object in BasicSearch and AdvancedSearch
+      var queryParamsObj = Object.assign({}, this.$route.query);
+      // Remove the `searchType` and `coordType` keys, which are not sent to Beacons
+      delete queryParamsObj.searchType;
+      delete queryParamsObj.coordType;
       var queryParamsString = "";
       for (var key in queryParamsObj) {
         if (queryParamsString != "") {


### PR DESCRIPTION
### Description
Previously after user made a query and reloaded the `/results` view, the search bar and/or input form would be cleared. This update fixes the issue, by re-reading the query string from the address bar, and re-populating the search bar and/or input form.

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
* Added new query parameter `searchType=basic` to `BasicSearch.vue` to help determine which search type was used on last query
* Added new query parameters `searchType=advanced` and `coordType=exact|range` to `AdvancedSearch.vue` to help determine which search- and query types were used on last query
* Updated `BasicSearch.vue` to read query string from address bar after page reload, and place the variant query to the search bar
* Updated `AdvancedSearch.vue` to read query string from address bar after page reload, and place the parameters into input form
* Updated `BeaconResults.vue` to strip non-specification parameters from address bar before sending request to aggregator