### PR TITLE
Fix number comparison bug

### DIFF
--- a/src/components/AdvancedSearch.vue
+++ b/src/components/AdvancedSearch.vue
@@ -318,7 +318,10 @@ export default {
       }
       // Validate exact coords
       if (this.coordType === "exact") {
-        if (this.start >= this.end && this.end != 0) {
+        if (
+          parseInt(this.start) >= parseInt(this.end) &&
+          parseInt(this.end) != 0
+        ) {
           this.errorMessages.push(
             "If End coordinate is set, it must be greater than Start coordinate."
           );
@@ -327,15 +330,27 @@ export default {
       }
       // Validate range coords
       if (this.coordType === "range") {
-        if (this.startMin >= this.endMin) {
+        if (parseInt(this.startMin) >= parseInt(this.endMin)) {
           this.errorMessages.push(
             "Minimum End coordinate must be greater than Minimum Start coordinate."
           );
           this.errorTooltip = true;
         }
-        if (this.startMax >= this.endMax) {
+        if (parseInt(this.startMin) >= parseInt(this.startMax)) {
+          this.errorMessages.push(
+            "Maximum Start coordinate must be greater than Minimum Start coordinate."
+          );
+          this.errorTooltip = true;
+        }
+        if (parseInt(this.startMax) >= parseInt(this.endMax)) {
           this.errorMessages.push(
             "Maximum End coordinate must be greater than Maximum Start coordinate."
+          );
+          this.errorTooltip = true;
+        }
+        if (parseInt(this.endMin) >= parseInt(this.endMax)) {
+          this.errorMessages.push(
+            "Maximum End coordinate must be greater than Minimum End coordinate."
           );
           this.errorTooltip = true;
         }

--- a/src/components/AdvancedSearch.vue
+++ b/src/components/AdvancedSearch.vue
@@ -237,7 +237,6 @@ export default {
   name: "AdvancedSearch",
   data() {
     return {
-      errorMessage: "",
       errorMessages: [],
       errorTooltip: false,
       coordType: "exact",
@@ -300,14 +299,11 @@ export default {
       this.$emit("changeSearchForm");
     },
     validateInput: function() {
-      this.errorMessage = "";
       this.errorMessages = [];
       this.errorTooltip = false;
       // Validate referenceBases field
       if (!this.refBases) {
         this.validated = false;
-        this.errorMessage =
-          "Reference Base(s) must be given, possible values are: A, T, C, G, N.";
         this.errorMessages.push(
           "Reference Base(s) must be given, possible values are: A, T, C, G, N."
         );
@@ -315,8 +311,6 @@ export default {
       }
       // Validate alternateBases field if variantType is unspecified
       if (this.altBases === "" && this.variantType == "Unspecified") {
-        this.errorMessage =
-          "Alternate Base(s) must be given if Variant Type is unspecified, possible values are: A, T, C, G, N.";
         this.errorMessages.push(
           "Alternate Base(s) must be given if Variant Type is unspecified, possible values are: A, T, C, G, N."
         );
@@ -325,8 +319,6 @@ export default {
       // Validate exact coords
       if (this.coordType === "exact") {
         if (this.start >= this.end && this.end != 0) {
-          this.errorMessage =
-            "End coordinate must be greater than Start coordinate.";
           this.errorMessages.push(
             "If End coordinate is set, it must be greater than Start coordinate."
           );


### PR DESCRIPTION
### Description
Fixed a bug, where the coordinates in the Advanced Search form would validate wrongly, as comparisons were made with strings, and not with integers. Also removed unused variable assignments.

The bug behaved in the following way:
```
start = "5"
end = "20"
start >= end  // true -> generate error
```
Intended behaviour:
```
start = 5
end = 20
start >= end  // false -> no error
```

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
* Removed deprecated variable assignments
* Converted coordinate strings to integers in coordinate-comparisons in `AdvancedSearch.vue`
* Added more coordinate comparison cases
