### PR TITLE
display_all_errors

### DIFF
--- a/src/components/BeaconResultTile.vue
+++ b/src/components/BeaconResultTile.vue
@@ -45,10 +45,16 @@
             ><b>Found</b></b-tag
           >
           <b-tag
-            v-if="!exists"
+            v-if="exists === false"
             class="accessibility-red-tag"
             title="No variants were found"
             ><b>Not Found</b></b-tag
+          >
+          <b-tag
+            v-if="exists === null"
+            class="accessibility-yellow-tag"
+            title="Error in connecting to beacon"
+            ><b>Currently not connecting</b></b-tag
           >
         </div>
       </article>
@@ -99,6 +105,10 @@ export default {
 }
 .accessibility-red-tag {
   background-color: #e90000;
+  color: #fff;
+}
+.accessibility-yellow-tag {
+  background-color: #e6e200;
   color: #fff;
 }
 </style>


### PR DESCRIPTION
### Description

Fix for issue 39. Now beacons which cannot be connected to can be seen. Note use beacon network  return_more_error_info branch

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->
Fixes #39
### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Changes Made

BeaconResults generates beacon Id for errored beacons and passes info down to BeaconResultTile.
BeaconResultTile displays errored beacons.