### PR TITLE
improved tests

### DIFF
--- a/cypress/integration/AdvancedSearch.test.ts
+++ b/cypress/integration/AdvancedSearch.test.ts
@@ -1,35 +1,36 @@
 describe("Advanced search", () => {
-    it("successfully loads", () => {
-        cy.visit("/");
-        cy.get('[data-testid="advanced"]').click();
-        cy.contains("Assembly");
-    });
-    it("can do a example search", () => {
-        cy.get('[data-testid="exampleButton"]').click();
-        cy.get('[data-testid="searchTest"]').click();
-        cy.contains("Development Beacon");
-        cy.contains("Display 6 result(s)");
-    });
-    it("can show unknown beacons", () => {
-        cy.get('[data-testid="unknownButton"]').click();
-        cy.contains("GA4GHBeacon at CSC");
-    });
-    it("can do an invalid search", () => {
-        cy.visit("/");
-        cy.get('[data-testid="advanced"]').click();
-        cy.get('[data-testid="exampleButton"]').click();
+  it("successfully loads", () => {
+    cy.visit("/");
+    cy.get('[data-testid="advanced"]').click();
+    cy.contains("Assembly");
+  });
+  it("can do a example search", () => {
+    cy.get('[data-testid="exampleButton"]').click();
+    cy.get('[data-testid="searchTest"]').click();
+    cy.contains("Development Beacon");
+    cy.contains("Display 6 result(s)");
+  });
+  it("can show unknown beacons", () => {
+    // expects aggregator to be in registry
+    cy.get('[data-testid="unknownButton"]').click();
+    cy.contains("GA4GHBeacon at CSC");
+  });
+  it("can do an invalid search", () => {
+    cy.visit("/");
+    cy.get('[data-testid="advanced"]').click();
+    cy.get('[data-testid="exampleButton"]').click();
 
-        cy.get('[data-testid="minStart"]').clear();
-        cy.get('[data-testid="maxStart"]').clear();
-        cy.get('[data-testid="minEnd"]').clear();
-        cy.get('[data-testid="maxEnd"]').clear();
+    cy.get('[data-testid="minStart"]').clear();
+    cy.get('[data-testid="maxStart"]').clear();
+    cy.get('[data-testid="minEnd"]').clear();
+    cy.get('[data-testid="maxEnd"]').clear();
 
-        cy.get('[data-testid="minStart"]').type("180");
-        cy.get('[data-testid="maxStart"]').type("190");
-        cy.get('[data-testid="minEnd"]').type("190");
-        cy.get('[data-testid="maxEnd"]').type("200");
+    cy.get('[data-testid="minStart"]').type("180");
+    cy.get('[data-testid="maxStart"]').type("190");
+    cy.get('[data-testid="minEnd"]').type("190");
+    cy.get('[data-testid="maxEnd"]').type("200");
 
-        cy.get('[data-testid="searchTest"]').click();
-        cy.contains("No results found.");
-    });
+    cy.get('[data-testid="searchTest"]').click();
+    cy.contains("No results found.");
+  });
 });

--- a/cypress/integration/BasicSearch.test.ts
+++ b/cypress/integration/BasicSearch.test.ts
@@ -10,20 +10,20 @@ describe("Basic Search", () => {
     cy.contains("Display 1 result(s)");
   });
   it("can display results", () => {
-    cy.get('[data-testid="displayResults"]').first().click();
+    cy.get('[data-testid="fi.rahtiapp.staging-elixirbeacon"]').click();
     cy.contains("urn:hg:1000genome dataset location");
     cy.contains("T > C");
   });
   it("can hide results", () => {
-    cy.get('[data-testid="displayResults"]').first().click();
+    cy.get('[data-testid="fi.rahtiapp.staging-elixirbeacon"]').click();
     cy.contains("urn:hg:1000genome dataset location").should("not.exist");
     cy.contains("T > C").should("not.exist");
   });
   it("can do an invalid search", () => {
     cy.visit("/");
+    cy.get('[data-testid="testBar"]').clear();
     cy.get('[data-testid="testBar"]').type("MT : 5 T > C");
     cy.get('[data-testid="searchButton"]').click();
     cy.contains("No results found.");
   });
 });
-

--- a/cypress/integration/Datasets.test.ts
+++ b/cypress/integration/Datasets.test.ts
@@ -5,11 +5,13 @@ describe("Datasets page", () => {
     cy.contains("Datasets");
   });
   it("can show beacons data sets", () => {
-    cy.get('[data-testid="beaconButton"]').first().click();
+    cy.get('[data-testid="beaconButton"]')
+      .contains("Development Beacon")
+      .click();
     cy.contains("urn:hg:1000genome");
   });
   it("can close datasets", () => {
-    cy.get('[data-testid="closeButton"]').first().click();
+    cy.get('[data-testid="closeButton"]').click();
     cy.contains("urn:hg:1000genome").should("not.exist");
   });
   it("can do a faulty search", () => {

--- a/src/components/BeaconResultTileDetails.vue
+++ b/src/components/BeaconResultTileDetails.vue
@@ -2,7 +2,7 @@
   <section>
     <div class="results-section">
       <b-button
-        data-testid="displayResults"
+        :data-testid="beaconId"
         @click="displayResults"
         class="show-more"
         type="is-primary"
@@ -105,7 +105,7 @@
 
 <script>
 export default {
-  props: ["results"],
+  props: ["results", "beaconId"],
   data() {
     return {
       display: false

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -47,6 +47,7 @@
             <BeaconResultTileDetails
               :key="resp.beaconId"
               v-bind:results="resp.datasetAlleleResponses"
+              :beaconId="resp.beaconId"
             ></BeaconResultTileDetails>
           </div>
         </section>


### PR DESCRIPTION
### Description

Tests can now find result button if there are multiple beacons.

### Related issues

#90 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Beacon results now receive  a prop which contains beaconId which then is used as data-testid to tell result buttons apart.

### Testing

- [x] Tests do not apply
