### PR TITLE
Refactor/history title and time

### DIFF
--- a/cypress/integration/History.test.ts
+++ b/cypress/integration/History.test.ts
@@ -1,0 +1,48 @@
+import "cypress-localstorage-commands";
+
+describe("Search history", () => {
+  it("contains searches", () => {
+    cy.clock().invoke("restore");
+    cy.clock(Date.UTC(2021, 10, 30), ["Date"]);
+    cy.visit("/");
+
+    cy.get('[data-testid="exampleButton"]').click();
+    cy.get('[data-testid="searchButton"]').click();
+
+    cy.visit("/history");
+
+    cy.clock().invoke("restore");
+    cy.clock(Date.UTC(2021, 11, 15), ["Date"]);
+    cy.visit("/");
+
+    cy.get('[data-testid="exampleButton"]').click();
+    cy.get('[data-testid="searchButton"]').click();
+
+    cy.visit("/history");
+    cy.clock().invoke("restore");
+    cy.clock(Date.UTC(2021, 11, 30), ["Date"]);
+    cy.visit("/");
+
+    cy.get('[data-testid="exampleButton"]').click();
+    cy.get('[data-testid="searchButton"]').click();
+
+    cy.visit("/history");
+
+    cy.contains("2021-11-30");
+    cy.contains("2021-12-15");
+    cy.contains("2021-12-30");
+  });
+  it("can be sorted desc", () => {
+    cy.get(".is-sortable > .th-wrap").click();
+    cy.get(".is-sortable > .th-wrap").click();
+    cy.get(':nth-child(1) > [data-label="Date"]').contains("2021-12-30");
+    cy.get(':nth-child(2) > [data-label="Date"]').contains("2021-12-15");
+    cy.get(':nth-child(3) > [data-label="Date"]').contains("2021-11-30");
+  });
+  it("can be sorted asc", () => {
+    cy.get(".is-sortable > .th-wrap").click();
+    cy.get(':nth-child(3) > [data-label="Date"]').contains("2021-12-30");
+    cy.get(':nth-child(2) > [data-label="Date"]').contains("2021-12-15");
+    cy.get(':nth-child(1) > [data-label="Date"]').contains("2021-11-30");
+  });
+});

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -228,9 +228,9 @@ export default {
           currentdate.getSeconds() +
           " " +
           currentdate.getDate() +
-          "." +
+          "/" +
           (currentdate.getMonth() + 1) +
-          "." +
+          "/" +
           currentdate.getFullYear();
         var search = {
           url: window.location.href,
@@ -240,17 +240,31 @@ export default {
         localStorage.setItem("searches", JSON.stringify(searches));
       } else {
         var currentdate = new Date();
+        console.log(currentdate);
+        var hours = currentdate.getHours();
+        var minutes = currentdate.getMinutes();
+        var seconds = currentdate.getSeconds();
+
+        if (hours < 10) {
+          hours = "0" + hours;
+        }
+        if (minutes < 10) {
+          minutes = "0" + minutes;
+        }
+        if (seconds < 10) {
+          seconds = "0" + seconds;
+        }
         var date =
-          currentdate.getHours() +
+          hours +
           ":" +
-          currentdate.getMinutes() +
+          minutes +
           ":" +
-          currentdate.getSeconds() +
+          seconds +
           " " +
           currentdate.getDate() +
-          "." +
+          "/" +
           (currentdate.getMonth() + 1) +
-          "." +
+          "/" +
           currentdate.getFullYear();
         var searches = JSON.parse(localStorage.getItem("searches"));
         var search = {

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -220,18 +220,31 @@ export default {
       if (localStorage.getItem("searches") == null) {
         var searches = [];
         var currentdate = new Date();
+        var hours = currentdate.getHours();
+        var minutes = currentdate.getMinutes();
+        var seconds = currentdate.getSeconds();
+
+        if (hours < 10) {
+          hours = "0" + hours;
+        }
+        if (minutes < 10) {
+          minutes = "0" + minutes;
+        }
+        if (seconds < 10) {
+          seconds = "0" + seconds;
+        }
         var date =
-          currentdate.getHours() +
-          ":" +
-          currentdate.getMinutes() +
-          ":" +
-          currentdate.getSeconds() +
-          " " +
-          currentdate.getDate() +
-          "/" +
+          currentdate.getFullYear() +
+          "-" +
           (currentdate.getMonth() + 1) +
-          "/" +
-          currentdate.getFullYear();
+          "-" +
+          currentdate.getDate() +
+          " " +
+          hours +
+          ":" +
+          minutes +
+          ":" +
+          seconds;
         var search = {
           url: window.location.href,
           date: date
@@ -255,17 +268,18 @@ export default {
           seconds = "0" + seconds;
         }
         var date =
+          currentdate.getFullYear() +
+          "-" +
+          (currentdate.getMonth() + 1) +
+          "-" +
+          currentdate.getDate() +
+          " " +
           hours +
           ":" +
           minutes +
           ":" +
-          seconds +
-          " " +
-          currentdate.getDate() +
-          "/" +
-          (currentdate.getMonth() + 1) +
-          "/" +
-          currentdate.getFullYear();
+          seconds;
+
         var searches = JSON.parse(localStorage.getItem("searches"));
         var search = {
           url: window.location.href,

--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -1,5 +1,5 @@
 <template>
-  <section title="History of searches in current seesion">
+  <section title="History of searches in current session">
     <nav class="panel">
       <p class="panel-heading">
         Search history
@@ -50,7 +50,7 @@
             </a>
           </router-link>
         </b-table-column>
-        <b-table-column field="date" label="Date" sortable v-slot="props">
+        <b-table-column field="date" label="Date" v-slot="props">
           <span class="tag is-info">
             {{ props.row.date }}
           </span>

--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -50,7 +50,7 @@
             </a>
           </router-link>
         </b-table-column>
-        <b-table-column field="date" label="Date" v-slot="props">
+        <b-table-column field="date" label="Date" sortable v-slot="props">
           <span class="tag is-info">
             {{ props.row.date }}
           </span>

--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -50,7 +50,13 @@
             </a>
           </router-link>
         </b-table-column>
-        <b-table-column field="date" label="Date" sortable v-slot="props">
+        <b-table-column
+          data-testid="dateButton"
+          field="date"
+          label="Date"
+          sortable
+          v-slot="props"
+        >
           <span class="tag is-info">
             {{ props.row.date }}
           </span>


### PR DESCRIPTION
### Description

Fixed time format to include 0 in minutes and seconds and fixed sorting

### Related issues

#135 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

- Fixed historypage label
- Beaconresults adds 0 to minutes and seconds if they are <10
- Fixed historypage sorting by changing the time format to yyyy-mm-dd hh:mm:ss

### Testing

[x] Manually

