### PR TITLE
prevent cookie toast duplicates #271

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -107,10 +107,15 @@ export default {
     },
     cookieToast: function () {
       // Check if cookies have been accepted, if not, show toast regarding cookies
-      if (!VueCookies.get("elixir-cookies")) {
+      if (
+        !VueCookies.get("elixir-cookies") &&
+        !VueCookies.get("elixir-cookies-toast-shown")
+      ) {
+        // Make a record of this toast being shown, so that it is not duplicated when view is changed
+        VueCookies.set("elixir-cookies-toast-shown", true, Infinity);
         this.$buefy.snackbar.open({
           indefinite: true,
-          queue: true,
+          queue: false,
           message:
             "Beacon Network utilises cookies and anonymous page view tracking. By using Beacon Network you accept the use of these cookies," +
             ' more information regarding cookies and optable tracking can be read from the <a href="/privacy" style="color:#000DFF">Privacy Policy</a>.' +
@@ -123,7 +128,7 @@ export default {
             VueCookies.set("elixir-tracking-consent", true, Infinity);
             VueCookies.set("elixir-cookies", "accepted", Infinity);
             this.$buefy.toast.open({
-              queue: true,
+              queue: false,
               message: "Cookies are in use!",
               position: "is-bottom-right",
             });


### PR DESCRIPTION
### Description
Previous change in #287 didn't actually fix the issue, the `queue` only hid the duplicates temporarily. Now when the toast is shown for the first time, a cookie is created to signify this event, so that a duplicate toast is not created again when changing views.
<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
- [x] Fixes #271 
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- new cookie generated and checked when spawning toast
<!-- List changes made. -->

