### PR TITLE
Display more info of datasets 

### DIFF
--- a/src/components/DatasetTile.vue
+++ b/src/components/DatasetTile.vue
@@ -1,0 +1,53 @@
+<template>
+  <section>
+    <div v-if="dataset != 'Unable to connect' && dataset != 'No datasets'">
+      <b-table
+        :data="dataset"
+        :striped="true"
+        ref="table"
+        class="column details-table"
+        detailed
+        :hover="true"
+        @details-open="(row) => $buefy.toast.open(`Expanded ${row.id}`)"
+      >
+        <b-table-column field="name" label="Dataset" v-slot="props">
+          {{ props.row.name }}
+        </b-table-column>
+        <b-table-column field="id" label="Dataset id" v-slot="props">
+          {{ props.row.id }}
+        </b-table-column>
+
+        <template #detail="props">
+          <article class="media">
+            <figure class="media-left"></figure>
+            <div class="media-content">
+              <div
+                class="content"
+                v-for="(row, index) in props.row"
+                v-bind:key="index"
+              >
+                <b>{{ index }}:</b>
+                {{ row }}
+              </div>
+            </div>
+          </article>
+        </template>
+      </b-table>
+    </div>
+    <div v-else>
+      <article class="media">
+        <figure class="media-left"></figure>
+        <div class="media-content">{{ dataset[0] }}</div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script>
+import axios from "axios";
+
+export default {
+  props: ["dataset"],
+  methods: {},
+};
+</script>

--- a/src/views/beaconDatasets.vue
+++ b/src/views/beaconDatasets.vue
@@ -3,6 +3,7 @@
   <section v-on:load="queryAPI" title="List of beacons and their datasets">
     <nav class="panel">
       <p class="panel-heading">Datasets</p>
+      <b class="panel-block">Search by dataset name or id</b>
       <div class="panel-block">
         <b-input
           data-testid="searchBar"
@@ -50,15 +51,7 @@
           {{ beacon.beaconName }}
         </a>
         <ul v-if="beacon.active">
-          <ul
-            class="indented"
-            v-for="dataset in beacon.datasets"
-            :key="dataset"
-          >
-            {{
-              dataset
-            }}
-          </ul>
+          <DatasetTile v-bind:dataset="beacon.datasets"> </DatasetTile>
         </ul>
       </ul>
     </nav>
@@ -67,8 +60,10 @@
 
 <script>
 import axios from "axios";
+import DatasetTile from "@/components/DatasetTile.vue";
 
 export default {
+  components: { DatasetTile },
   data() {
     return {
       searchValue: "",
@@ -77,6 +72,10 @@ export default {
       error: "",
       registry: process.env.VUE_APP_REGISTRY_URL,
       active: false,
+      columns: [
+        { field: "beaconName", label: "Beacon name", searchable: true },
+        { field: "name", label: "Dataset name", searchable: true },
+      ],
     };
   },
   methods: {
@@ -91,8 +90,19 @@ export default {
       vm.closeDatasets();
       for (const beacon of vm.beaconsAndDataSets) {
         beacon.datasets.forEach((dataset) => {
-          if (dataset.toLowerCase().includes(vm.searchValue.toLowerCase())) {
-            beacon.active = true;
+          if (dataset.name != undefined) {
+            if (
+              dataset.name.toLowerCase().includes(vm.searchValue.toLowerCase())
+            ) {
+              beacon.active = true;
+            }
+          }
+          if (dataset.id != undefined) {
+            if (
+              dataset.id.toLowerCase().includes(vm.searchValue.toLowerCase())
+            ) {
+              beacon.active = true;
+            }
           }
         });
       }
@@ -111,7 +121,7 @@ export default {
           .then((response) => {
             const datasets = [];
             for (const data of response.data.datasets) {
-              datasets.push(data.id);
+              datasets.push(data);
             }
             if (datasets.length == 0) {
               datasets.push("No datasets");
@@ -144,6 +154,8 @@ export default {
   },
   beforeMount() {
     this.queryAPI();
+    console.log(this.beaconsAndDataSets);
+    console.log(this.beacons);
   },
 };
 </script>


### PR DESCRIPTION
### Description

Datasets page now displays all info of them.

### Related issues
Fixes issue #221 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Added DatasetTile.vue which displays all beacons datasets in a table.

beacondataSets.vue uses DatasetTile in beacon list.

- [x] Tests do not apply

