### PR TITLE
fixed date column

### DIFF
--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -119,11 +119,10 @@ export default {
     },
     parseUrl: function (url) {
       var splitUrl = url.split("/");
-      console.log;
       return splitUrl[3];
     },
     urlIsBasic: function (url) {
-      if (url.includes("basic") || url.includes("searchInInput")) {
+      if (url.includes("basic")) {
         return true;
       } else {
         return false;


### PR DESCRIPTION
### Description

Beacon2 urls in history page were too long and the date column was moved because fo this.

### Related issues

#327 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

HIstory.vue changed how urls are cut. Also removed unnecessary console.log.

### Testing

-[] Peer review
