### PR TITLE
Bugfix/page reload changes search

### DIFF
--- a/cypress/integration/BasicSearch.test.ts
+++ b/cypress/integration/BasicSearch.test.ts
@@ -13,7 +13,7 @@ describe("Basic Search", () => {
   });
   it("can display results", () => {
     cy.get('[data-testid="fi.rahtiapp.staging-elixirbeacon"]').click();
-
+    cy.wait(3000);
     cy.contains("urn:hg:1000genome dataset location");
     cy.contains("T > C");
   });

--- a/cypress/integration/BasicSearch.test.ts
+++ b/cypress/integration/BasicSearch.test.ts
@@ -13,7 +13,7 @@ describe("Basic Search", () => {
   });
   it("can display results", () => {
     cy.get('[data-testid="fi.rahtiapp.staging-elixirbeacon"]').click();
-    cy.wait(3000);
+
     cy.contains("urn:hg:1000genome dataset location");
     cy.contains("T > C");
   });

--- a/cypress/integration/ListingsSearch.test.ts
+++ b/cypress/integration/ListingsSearch.test.ts
@@ -19,7 +19,7 @@ describe("Listings search", () => {
     cy.get(".navbar-burger").click();
     cy.get('[data-testid="historyButton"]').click();
     cy.contains(
-      "results?searchInInput=biosamples&id=SAMN03283350&searchByInput=individuals"
+      "results?searchType=listing&searchInInput=biosamples&id=SAMN03283350&searchByInput=individuals"
     );
   });
 });

--- a/src/components/BeaconResults.vue
+++ b/src/components/BeaconResults.vue
@@ -24,7 +24,6 @@
           >
         </div>
       </b-field>
-      {{ beaconV2 }}
       <p class="subtitle" v-if="beaconV2">Filter by</p>
       <b-field v-if="beaconV2">
         <div

--- a/src/components/ListingV2.vue
+++ b/src/components/ListingV2.vue
@@ -193,6 +193,7 @@ export default {
       vm.validateInput();
       if (vm.validated) {
         var queryObj = {
+          searchType: "listing",
           searchInInput: this.list[0].searchInInput,
           id: this.list[0].searchValue,
           searchByInput: this.list[0].searchByInput,
@@ -272,6 +273,25 @@ export default {
   },
   beforeMount() {
     this.addRow();
+    if (this.$route.query.id != undefined) {
+      this.list = [];
+      this.list.push({
+        searchInInput: this.$route.query.searchInInput,
+        searchInInputs: [
+          "individuals",
+          "biosamples",
+          "g_variants",
+          "runs",
+          "analyses",
+          "interactors",
+          "cohorts",
+        ],
+        searchValue: this.$route.query.id,
+        toId: "0",
+        searchByInput: this.$route.query.searchByInput,
+        searchByInputs: [this.$route.query.searchByInput],
+      });
+    }
   },
 };
 </script>

--- a/src/views/Guide.vue
+++ b/src/views/Guide.vue
@@ -101,7 +101,7 @@
     <p>
       Search queries in beacon 2.x work much like they did in beacon 1.1.0,
       except now queries can be filtered using the following models from the
-      dopdown field: <b>individuals, biosamples, g-variants and cohorts </b>.
+      dropdown field: <b>individuals, biosamples, g-variants and cohorts </b>.
     </p>
     <h4>Listings search</h4>
     <p>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -48,7 +48,6 @@ import BasicSearchV2 from "@/components/BasicSearchV2.vue";
 import AdvancedSearchV2 from "@/components/AdvancedSearchV2.vue";
 import ListingV2 from "@/components/ListingV2.vue";
 import VueCookies from "vue-cookies";
-import BasicSearchVue from "@/components/BasicSearch.vue";
 
 export default {
   name: "home",
@@ -65,7 +64,6 @@ export default {
       results: false,
       toggleV2: false,
       componentName: BasicSearch,
-      previous: BasicSearch,
     };
   },
 
@@ -85,7 +83,7 @@ export default {
         this.componentName = AdvancedSearch;
       } else if (this.componentName == AdvancedSearch) {
         this.componentName = AdvancedSearchV2;
-      } else if (this.componentName == ListingV2) {
+      } else if (this.componentName == ListingV2 && !this.toggleV2) {
         this.componentName = BasicSearch;
       }
     },
@@ -158,7 +156,7 @@ export default {
   },
   beforeMount() {
     this.cookieToast();
-    if (this.$route.query.searchInInput != null) {
+    if (this.$route.query.searchInInput != undefined) {
       this.toggleV2 = true;
     } else {
       this.toggleV2 = false;
@@ -168,6 +166,11 @@ export default {
         this.componentName = AdvancedSearchV2;
       } else {
         this.componentName = AdvancedSearch;
+      }
+    }
+    if (this.$route.query.searchType == "listing") {
+      if (this.toggleV2) {
+        this.componentName = ListingV2;
       }
     }
   },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -85,6 +85,8 @@ export default {
         this.componentName = AdvancedSearch;
       } else if (this.componentName == AdvancedSearch) {
         this.componentName = AdvancedSearchV2;
+      } else if (this.componentName == ListingV2) {
+        this.componentName = BasicSearch;
       }
     },
     setFormToA: function () {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -161,6 +161,13 @@ export default {
     } else {
       this.toggleV2 = false;
     }
+    if (this.$route.query.searchType == "advanced") {
+      if (!this.toggleV2) {
+        this.componentName = AdvancedSearchV2;
+      } else {
+        this.componentName = AdvancedSearch;
+      }
+    }
   },
 };
 </script>


### PR DESCRIPTION
### Description

Reloading page after search resets search form to basic from advanced/listing search.

### Related issues

#420 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes Made

Home.vue added feature which changes form type based on url.

ListingV2.vue and AdvancedSearchv2.vue now get query values from the url before rendering components.


### Testing

- [x] Tests do not apply


