### PR TITLE
deprecated e2e tests option cypress github action

### DIFF
--- a/.github/workflows/E2Etests.yml
+++ b/.github/workflows/E2Etests.yml
@@ -93,7 +93,6 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           browser: ${{ matrix.browser }}
-          headless: true
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION

### Description

<!-- Please include a summary of the change or any information deemed important. -->
this runs in headless by default as of cypress 8+

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

<!-- List changes made. -->
- remove deprecated `headless` param from cypress github action

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Tests do not apply


### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
